### PR TITLE
Remember last used name via localStorage

### DIFF
--- a/src/effects/addEntryEffects.ts
+++ b/src/effects/addEntryEffects.ts
@@ -5,6 +5,7 @@ import { actions, NewEntryAction } from "../store/newEntryActions";
 import { AppState } from "../store/types";
 import { LiftLogEntry, SetsReps } from "../types/liftTypes";
 import { getSets } from "../utils/liftUtils";
+import { setLastUsedName } from "../utils/localStorageUtils";
 
 export const addLogEntry = (
   logName: string
@@ -45,6 +46,7 @@ export const addLogEntry = (
   return liftLogService
     .addEntry(logName, newEntry)
     .then(() => {
+      setLastUsedName(newEntry.name);
       dispatch(actions.addLogEntry.success());
       dispatch(dialogActions.reset());
     })

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -4,7 +4,9 @@ import thunkMiddleware from "redux-thunk";
 import LiftLogService from "../services/liftLogService";
 import { dialogReducer } from "../store/dialogReducer";
 import { liftLogReducer } from "../store/liftLogReducer";
+import { actions as newEntryActions } from "../store/newEntryActions";
 import { newEntryReducer } from "../store/newEntryReducer";
+import { getLastUsedName } from "../utils/localStorageUtils";
 
 const rootReducer = combineReducers({
   liftLogState: liftLogReducer,
@@ -15,10 +17,19 @@ const rootReducer = combineReducers({
 const composeEnhancers = composeWithDevTools({ serialize: true });
 
 export const configureStore = (liftLogService: LiftLogService) => {
-  return createStore(
+  const store = createStore(
     rootReducer,
     composeEnhancers(
       applyMiddleware(thunkMiddleware.withExtraArgument(liftLogService))
     )
   );
+
+  // Pre-fill the last used name from a previous session here, at the
+  // composition root, so the reducer's initial state stays side-effect free.
+  const lastUsedName = getLastUsedName();
+  if (lastUsedName) {
+    store.dispatch(newEntryActions.changeName(lastUsedName));
+  }
+
+  return store;
 };

--- a/src/store/newEntryReducer.ts
+++ b/src/store/newEntryReducer.ts
@@ -1,3 +1,4 @@
+import { getLastUsedName } from "src/utils/localStorageUtils";
 import { toValidFloatOrNull } from "src/utils/numberUtils";
 import { getType } from "typesafe-actions";
 import { actions, NewEntryAction } from "./newEntryActions";
@@ -5,7 +6,7 @@ import { NewEntryState } from "./types";
 
 const initialState: NewEntryState = {
   date: new Date(),
-  name: "",
+  name: getLastUsedName(),
   weightLifted: null,
   weightLiftedString: ""
 };

--- a/src/store/newEntryReducer.ts
+++ b/src/store/newEntryReducer.ts
@@ -1,4 +1,3 @@
-import { getLastUsedName } from "src/utils/localStorageUtils";
 import { toValidFloatOrNull } from "src/utils/numberUtils";
 import { getType } from "typesafe-actions";
 import { actions, NewEntryAction } from "./newEntryActions";
@@ -6,7 +5,7 @@ import { NewEntryState } from "./types";
 
 const initialState: NewEntryState = {
   date: new Date(),
-  name: getLastUsedName(),
+  name: "",
   weightLifted: null,
   weightLiftedString: ""
 };

--- a/src/utils/localStorageUtils.test.ts
+++ b/src/utils/localStorageUtils.test.ts
@@ -1,0 +1,22 @@
+import { getLastUsedName, setLastUsedName } from "./localStorageUtils";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+it("returns an empty string when no name has been saved yet", () => {
+  expect(getLastUsedName()).toBe("");
+});
+
+it("persists and retrieves the last used name", () => {
+  setLastUsedName("Arnold");
+
+  expect(getLastUsedName()).toBe("Arnold");
+});
+
+it("overwrites the previously saved name", () => {
+  setLastUsedName("Arnold");
+  setLastUsedName("Ronnie");
+
+  expect(getLastUsedName()).toBe("Ronnie");
+});

--- a/src/utils/localStorageUtils.ts
+++ b/src/utils/localStorageUtils.ts
@@ -1,0 +1,18 @@
+const LAST_USED_NAME_KEY = "lift-log.lastUsedName";
+
+export const getLastUsedName = (): string => {
+  try {
+    return window.localStorage.getItem(LAST_USED_NAME_KEY) || "";
+  } catch {
+    // Accessing localStorage can throw (e.g. private mode / disabled storage).
+    return "";
+  }
+};
+
+export const setLastUsedName = (name: string): void => {
+  try {
+    window.localStorage.setItem(LAST_USED_NAME_KEY, name);
+  } catch {
+    // Ignore write errors (e.g. storage disabled / quota exceeded).
+  }
+};


### PR DESCRIPTION
## What

When adding a log entry, the **Name** you type is now saved to the device (browser `localStorage`) and pre-filled the next time you open the board, so you don't have to re-enter it.

## How

- **New** [src/utils/localStorageUtils.ts](src/utils/localStorageUtils.ts) — `getLastUsedName()` / `setLastUsedName()` helpers, each guarded with `try/catch` so private-mode / disabled-storage / quota errors degrade gracefully to "no saved name" instead of throwing.
- [src/effects/addEntryEffects.ts](src/effects/addEntryEffects.ts) — **write** the name via `setLastUsedName(newEntry.name)` only on a **successful** add (inside the thunk's `.then`).
- [src/redux/store.ts](src/redux/store.ts) — **read** the saved name at store creation (`configureStore`) and dispatch `changeName` to pre-fill it. Doing the hydration at the composition root keeps the reducer's initial state side-effect free.
- [src/store/newEntryReducer.ts](src/store/newEntryReducer.ts) — `initialState` stays a pure constant (`name: ""`).
- **New** [src/utils/localStorageUtils.test.ts](src/utils/localStorageUtils.test.ts) — unit tests for the default, persist/retrieve, and overwrite cases.

A single global key (`lift-log.lastUsedName`) is used — the name follows the device/user, matching the "so I don't have to enter it again" goal.

## Testing

- `tsc --noEmit` — clean
- `tslint` on changed files — clean
- `react-scripts-ts test` — **14/14 passing** (incl. 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
