### PR TITLE
Fix "global is not defined" crash in production build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig({
   // Keep the classic JSX runtime so the codebase's `import * as React`
   // stays required (works with React 16 and `noUnusedLocals`).
   plugins: [react({ jsxRuntime: "classic" })],
+  // CRA/webpack shimmed Node's `global` in the browser; Vite does not. Some
+  // transitive deps (create-react-context via react-popper/reactstrap Tooltip)
+  // reference a bare `global`, which throws "global is not defined" at runtime
+  // and crashes the app before it mounts. Map it to globalThis.
+  define: {
+    global: "globalThis"
+  },
   // Keep supporting the existing REACT_APP_* env vars (e.g. on Netlify)
   // in addition to Vite's native VITE_* prefix.
   envPrefix: ["VITE_", "REACT_APP_"],


### PR DESCRIPTION
## Problem

After the Vite migration, the deployed site (e.g. https://lift-log-ts.netlify.app/testlog) renders a **blank page**.

## Diagnosis

I inspected the live deployment and ruled out the usual suspects:

| Check | Result |
|---|---|
| `index.html` + assets served | ✅ 200, correct MIME (`application/javascript`) |
| API base URL baked into bundle | ✅ `https://liftlogwebapp.azurewebsites.net/api/liftlogs` (prod, **not** localhost) |
| API endpoint `/api/liftlogs/testlog` | ✅ 200, returns the board JSON |

So the bundle loads but **crashes at runtime**. The cause is a bare `global` reference:

```js
var n = "__global_unique_id__";
module.exports = function () { return global[n] = (global[n] || 0) + 1 };
```

This is `create-react-context`, pulled in via `react-popper` → `reactstrap`'s `Tooltip` (used in `InputModeSwitch`). Webpack (CRA) shimmed Node's `global` in the browser; **Vite does not**, so this throws `ReferenceError: global is not defined` before React mounts → blank page.

Proven in a browser-like context (no Node `global`):
```
OLD (bare global) THROWS -> ReferenceError: global is not defined
NEW (globalThis)  -> ok
```

## Fix

Map `global` to `globalThis` in [vite.config.ts](vite.config.ts):

```ts
define: {
  global: "globalThis"
}
```

## Verification

- Rebuilt bundle: the unguarded `global[...]` is now `globalThis[...]`; **no bare `global` references remain**; other Node-isms (`process.env`, `require`, `Buffer`) are absent or guarded.
- `npm run build` ✅ · `eslint` 0 problems ✅ · `vitest` 14/14 ✅

## After merge

Re-deploy on Netlify; the page should render. (No env-var changes needed — that part was already working.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
