### PR TITLE
Fix blank page: unwrap CJS default exports (DatePicker, AnimateHeight)

### DIFF
--- a/src/components/AddLogEntry.tsx
+++ b/src/components/AddLogEntry.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import DatePicker from "react-datepicker";
+import DatePickerImport from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { connect } from "react-redux";
 import { Button } from "reactstrap";
@@ -10,8 +10,11 @@ import { getSetsReps } from "../store/selectors";
 import { AppState } from "../store/types";
 import { SetsReps } from "../types/liftTypes";
 import { formatRepsSets } from "../utils/liftUtils";
+import { interopDefault } from "../utils/interopDefault";
 import "./AddLogEntry.css";
 import AddRepsModal from "./AddRepsModal";
+
+const DatePicker = interopDefault(DatePickerImport);
 
 export type StateProps = {
   name: string;

--- a/src/components/AddRepsModal/LiftInfo/Comment.tsx
+++ b/src/components/AddRepsModal/LiftInfo/Comment.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
-import AnimateHeight from "react-animate-height";
+import AnimateHeightImport from "react-animate-height";
 import { Button, Fade, Input } from "reactstrap";
+import { interopDefault } from "../../../utils/interopDefault";
+
+const AnimateHeight = interopDefault(AnimateHeightImport);
 
 export type CommentStateProps = {
   comment: string;

--- a/src/components/AddRepsModal/LiftInfo/Links.tsx
+++ b/src/components/AddRepsModal/LiftInfo/Links.tsx
@@ -1,6 +1,6 @@
 import Octicon, { getIconByName } from "@githubprimer/octicons-react";
 import * as React from "react";
-import AnimateHeight from "react-animate-height";
+import AnimateHeightImport from "react-animate-height";
 import {
   Button,
   FormText,
@@ -10,6 +10,9 @@ import {
 } from "reactstrap";
 import { MAX_NUMBER_OF_LINKS } from "../../../store/dialogReducer";
 import { LiftInfoLink } from "../../../types/liftTypes";
+import { interopDefault } from "../../../utils/interopDefault";
+
+const AnimateHeight = interopDefault(AnimateHeightImport);
 
 export type LinksStateProps = {
   links: ReadonlyArray<LiftInfoLink>;

--- a/src/utils/interopDefault.ts
+++ b/src/utils/interopDefault.ts
@@ -1,0 +1,11 @@
+// Vite (esbuild in dev, Rollup in prod) can surface a CommonJS module's whole
+// namespace object as the default import (e.g. `{ default: Component, ... }`)
+// instead of the component itself. React then throws "Element type is invalid
+// ... but got: object". The old webpack toolchain unwrapped this automatically.
+//
+// This normalises such an import back to its real default export. It is a
+// no-op for modules whose default is already the value we want.
+export const interopDefault = <T>(mod: T): T => {
+  const maybe = mod as { default?: T };
+  return maybe && maybe.default ? maybe.default : mod;
+};


### PR DESCRIPTION
## Problem

After the global-shim fix (#54), the deployed page was **still blank**. I drove the live site in headless Chrome and captured the real error (the earlier static analysis couldn't see it):

```
Uncaught Error: Minified React error #130
  -> "Element type is invalid: expected a string or class/function but got: object"
  (un-minified, from the dev build: "Check the render method of AddLogEntry", at AddLogEntry.tsx:47)
```

## Cause

`react-datepicker` and `react-animate-height` are CommonJS modules that set `__esModule` **and** export both a `default` and named exports. Vite's dependency optimizer marks them `needsInterop=true` and surfaces the **default import as the whole namespace object** — `{ default: Component, CalendarContainer, … }` — instead of the component. So `<DatePicker />` is given an object → React error #130 → blank page.

webpack (the old `react-scripts-ts`) unwrapped this automatically, which is why it worked before the migration.

`@githubprimer/octicons-react` ships an ESM build (`needsInterop=false`), so its default import resolves correctly and is left untouched.

## Fix

A small [`interopDefault`](src/utils/interopDefault.ts) helper that returns `mod.default` when present (no-op otherwise), applied at the three affected import sites:

- [AddLogEntry.tsx](src/components/AddLogEntry.tsx) — `DatePicker`
- [Comment.tsx](src/components/AddRepsModal/LiftInfo/Comment.tsx) — `AnimateHeight`
- [Links.tsx](src/components/AddRepsModal/LiftInfo/Links.tsx) — `AnimateHeight`

It works the same in dev (esbuild) and prod (Rollup), so it's robust regardless of which bundler path runs.

## Verification — this time in a real browser

I built the **production** bundle and loaded it in headless Chrome (with the API mocked so the form is enabled):

- Initial render: board title and **12 lift rows** render; date picker present.
- Clicked **Add** → the reps modal opens, mounting `AnimateHeight` (Comment/Links) **and** `Octicon` (renders an SVG).
- **0 console/page errors.**

tsc clean · ESLint 0 problems · Vitest 14/14.

## After merge

Re-deploy — the page should now render. This was the missing browser-level check that local `vite build`/dev-HTTP smoke tests didn't catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
